### PR TITLE
Update hooks.php

### DIFF
--- a/modules/addons/order_management/hooks.php
+++ b/modules/addons/order_management/hooks.php
@@ -116,6 +116,8 @@ add_hook('InvoicePaid', 1, function($vars) {
                 
                 if ($acceptOrderResults['result'] != 'success') {
                     logActivity("An error occured accepting order $invoiceID: " . $acceptOrderResults['result']);
+                } else {
+                    break;
                 }
             }
         }


### PR DESCRIPTION
Because add_hook() run every an order is paid, there is only one invoice appear when hook is triggered. In the for loop at line 105, if we found an orders (match with $paidInvoiceID) that is just paid, active it and then stop the loop to reduce unnecessary loops.